### PR TITLE
QENG-6412 Fixes after testing in centos

### DIFF
--- a/files/memcached_centos.conf
+++ b/files/memcached_centos.conf
@@ -1,0 +1,6 @@
+# This file is managed by Puppet.
+CACHESIZE="128"
+PORT="11211"
+USER="memcached"
+MAXCONN="1024"
+OPTIONS="-l 127.0.0.1 -s /var/run/memcached/memcached.sock"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -56,7 +56,7 @@ class waylon::install (
     ruby_version => $ruby_version,
     version      => $unicorn_version,
     skip_docs    => true,
-  } ->
+  }
 
   if $waylon_version != false {
     rbenv::gem { 'waylon':

--- a/manifests/memcached.pp
+++ b/manifests/memcached.pp
@@ -3,23 +3,36 @@
 # Jenkins, thus reducing API hits.
 #
 class waylon::memcached {
+  case $::operatingsystem {
+    'debian': {
+      $owner_memcached = 'nobody'
+      $memcached_conf_location = '/etc/memcached_local.conf'
+      $memcached_conf_source = 'puppet:///modules/waylon/memcached.conf'
+    }
+    'centos': {
+      $owner_memcached = 'memcached'
+      $memcached_conf_location = '/etc/sysconfig/memcached'
+      $memcached_conf_source = 'puppet:///modules/waylon/memcached_centos.conf'
+    }
+  }
+
   package { 'memcached':
     ensure => installed,
   }
 
-  file { '/etc/memcached_local.conf':
+  file { $memcached_conf_location:
     ensure  => file,
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    source  => 'puppet:///modules/waylon/memcached.conf',
+    source  => $memcached_conf_source,
     notify  => Service['memcached'],
     require => Package['memcached'],
   }
 
   file { '/var/run/memcached':
     ensure => directory,
-    owner  => 'nobody',
+    owner  => $owner_memcached,
     group  => 'root',
     mode   => '0755',
   }

--- a/manifests/memcached.pp
+++ b/manifests/memcached.pp
@@ -41,7 +41,7 @@ class waylon::memcached {
     ensure  => running,
     enable  => true,
     require => [
-      File['/etc/memcached_local.conf'],
+      File[$memcached_conf_location],
       File['/var/run/memcached'],
     ],
   }


### PR DESCRIPTION
Puppet compilation error, so removed typo with resource ordering
Also fixed the memcached settings for centos. It was being started with the default settings
which mainly missed the socket waylon is expecting.